### PR TITLE
Changes in DTS in order to properly estimate the joint prob distribution

### DIFF
--- a/tests/bandits/test_bandits.py
+++ b/tests/bandits/test_bandits.py
@@ -42,6 +42,14 @@ class BetaThompsonSamplingTest(TestCase):
 
 
 class DirichletThompsonSamplingTest(TestCase):
+    def test_calculate_cond_prob(self):
+        num_arms = 3
+        bandit = DirichletThompsonSampling(num_arms=num_arms)
+
+        probs = bandit._calculate_cond_prob(0)
+        num_precision_error = 1e-10
+        assert sum(probs) > 1.0 - num_precision_error
+
     def test_choose(self):
         num_arms = 3
         bandit = DirichletThompsonSampling(num_arms=num_arms)
@@ -60,7 +68,7 @@ class DirichletThompsonSamplingTest(TestCase):
         bandit.update(1, reward=1.0, context={'previous_action': 2})
 
         assert (bandit.rewards == [
-            [[1.], [1.], [1.], [1.]],
+            [[1.], [1.], [2.], [1.]],
             [[1.], [1.], [2.], [1.]],
             [[1.], [2.], [1.], [1.]],
             [[1.], [1.], [1.], [1.]]]).all()


### PR DESCRIPTION
The joint probability distribution isn't properly estimated. What we have instead of P(i,j) is P(i|j). We fix that in this PR by multiplying P(i|j)*P(i).

P(i|j)*P(i)=P(i,j) even if it is not straightforward , given that we assume symmetry between transition (i->j and j->i are the same thing), we can replace P(j|i) with P(i|j) and vice versa.

Note: The code is twice as slow as sampling has to happen twice, one for conditional probs and one for unconditionals.